### PR TITLE
feature: Add html templating

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Skull and Roses</title>
-  <link rel="stylesheet" href="css/style.css"> 
+  <link rel="stylesheet" href="/static/css/style.css" type="text/css">
+
 </head>
 
 <body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<head>
+  <title>{{.PageTitle}} </title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/static/css/style.css">
+</head>
+
+<body>
+  <h1>{{.PageTitle}}</h1>
+
+  <ul>
+    {{range .Todos}}
+      {{ if .Done}}
+        <li class="done">{{.Title}}</li>
+      {{ else }}
+        <li>{{.Title}}</li>
+      {{end}}
+    {{end}}
+  </ul>
+  <script src="/static/js/index.js" type="text/javascript"></script>
+</body>


### PR DESCRIPTION
# Aim

Address Issue #2 - allowing html templates to be created


# Changes

- Adds the ability to run data through templates & respond with html
  - Based on [this tutorial](https://gowebexamples.com/templates/)
- Re-configures the serving of static files to run through the [`go-chi`](https://github.com/go-chi/chi) router

# Result

When hitting the path `/todo/http://localhost:3333/todo/some%20list%20of%20jobs`
- ✅The tutorials `TODO` html is displayed
- ✅The `<h1>` and title of the page are both derived from the path "some list of jobs"
![image](https://github.com/Marcamillian/skull-and-roses-go/assets/3187001/c9d11872-c606-4818-bac8-b23f7e58baeb)

# Potential Future Work
- Add nested templates as outlined in [this stack overflow thread](https://stackoverflow.com/questions/11467731/is-it-possible-to-have-nested-templates-in-go-using-the-standard-library)